### PR TITLE
membersテーブルの作成

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ https://phinx.org/
 
 - コンテナが立ち上がっていない場合は、(本README.mdがあるディレクトリで) docker-compose up でコンテナを立ち上げる
 - `docker-compose exec php bash` で、phpコンテナの中（Linux）に入る
+- `composer install`を実行
 - `vendor/bin/phinx status` が実行できることを確認する
 
 #### 自分がテーブルを追加する場合

--- a/php/www/html/db/migrations/20200412081235_add_user_table.php
+++ b/php/www/html/db/migrations/20200412081235_add_user_table.php
@@ -4,37 +4,14 @@ use Phinx\Migration\AbstractMigration;
 
 class AddUserTable extends AbstractMigration
 {
-    /**
-     * Change Method.
-     *
-     * Write your reversible migrations using this method.
-     *
-     * More information on writing migrations is available here:
-     * https://book.cakephp.org/phinx/0/en/migrations.html
-     *
-     * The following commands can be used in this method and Phinx will
-     * automatically reverse them when rolling back:
-     *
-     *    createTable
-     *    renameTable
-     *    addColumn
-     *    addCustomColumn
-     *    renameColumn
-     *    addIndex
-     *    addForeignKey
-     *
-     * Any other destructive changes will result in an error when trying to
-     * rollback the migration.
-     *
-     * Remember to call "create()" or "update()" and NOT "save()" when working
-     * with the Table class.
-     */
-    public function change() {
-        $table = $this->table('users');
-        $table->addColumn('name', 'string', ['null' => false])
-            ->addColumn('password', 'string', ['null' => false])
-            ->addColumn('created', 'datetime')
-            ->addColumn('modified', 'datetime')
+    public function change()
+    {
+        $table = $this->table('members');
+        $table->addColumn('name', 'string', ['limit' => 20], ['null' => false])
+            ->addColumn('password', 'string', ['limit' => 40], ['null' => false])
+            ->addColumn('email', 'string', ['limit' => 255], ['null' => false])
+            ->addColumn('created_date', 'datetime')
+            ->addColumn('updated_date', 'datetime')
             ->create();
     }
 }


### PR DESCRIPTION
# 概要
- READMEのphinx実行手順に`composer install` を追加
- membersテーブル作成のためのmigrationファイル作成
- migrationの実行

# 実行結果
`show tables;`
<img width="300" alt="スクリーンショット 2020-04-19 19 49 12" src="https://user-images.githubusercontent.com/54798551/79685964-932adb80-8277-11ea-82ff-93bc3ee10d08.png">

 `show columns members;`
<img width="500" alt="スクリーンショット 2020-04-19 19 48 01" src="https://user-images.githubusercontent.com/54798551/79685973-9f169d80-8277-11ea-8ecb-8cccdffc55c0.png">

