### PR TITLE
メンバー詳細ページの作成

### DIFF
--- a/php/www/html/composer.lock
+++ b/php/www/html/composer.lock
@@ -8,16 +8,16 @@
     "packages": [
         {
             "name": "cakephp/collection",
-            "version": "4.0.5",
+            "version": "4.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/cakephp/collection.git",
-                "reference": "df155a72defbafbe18b24e8f6fc9cc99fde46f8a"
+                "reference": "18393a716322585c86b46c852c396534d925926a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cakephp/collection/zipball/df155a72defbafbe18b24e8f6fc9cc99fde46f8a",
-                "reference": "df155a72defbafbe18b24e8f6fc9cc99fde46f8a",
+                "url": "https://api.github.com/repos/cakephp/collection/zipball/18393a716322585c86b46c852c396534d925926a",
+                "reference": "18393a716322585c86b46c852c396534d925926a",
                 "shasum": ""
             },
             "require": {
@@ -50,20 +50,20 @@
                 "collections",
                 "iterators"
             ],
-            "time": "2020-03-18T18:19:21+00:00"
+            "time": "2020-04-17T08:12:09+00:00"
         },
         {
             "name": "cakephp/core",
-            "version": "4.0.5",
+            "version": "4.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/cakephp/core.git",
-                "reference": "161491ceeaf2bbb4471f5af9832ee08e4408a274"
+                "reference": "d8463fec4f59cc1b9e4bd0faaa64991b130b961a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cakephp/core/zipball/161491ceeaf2bbb4471f5af9832ee08e4408a274",
-                "reference": "161491ceeaf2bbb4471f5af9832ee08e4408a274",
+                "url": "https://api.github.com/repos/cakephp/core/zipball/d8463fec4f59cc1b9e4bd0faaa64991b130b961a",
+                "reference": "d8463fec4f59cc1b9e4bd0faaa64991b130b961a",
                 "shasum": ""
             },
             "require": {
@@ -100,20 +100,20 @@
                 "core",
                 "framework"
             ],
-            "time": "2020-03-18T18:19:21+00:00"
+            "time": "2020-04-17T13:58:27+00:00"
         },
         {
             "name": "cakephp/database",
-            "version": "4.0.5",
+            "version": "4.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/cakephp/database.git",
-                "reference": "62bdc57e684cde9a772a8ce2a0627b7f4a0a4b1a"
+                "reference": "ea6fb36fc9f76c5c6e5998380f7d7e485c867ab5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cakephp/database/zipball/62bdc57e684cde9a772a8ce2a0627b7f4a0a4b1a",
-                "reference": "62bdc57e684cde9a772a8ce2a0627b7f4a0a4b1a",
+                "url": "https://api.github.com/repos/cakephp/database/zipball/ea6fb36fc9f76c5c6e5998380f7d7e485c867ab5",
+                "reference": "ea6fb36fc9f76c5c6e5998380f7d7e485c867ab5",
                 "shasum": ""
             },
             "require": {
@@ -149,20 +149,20 @@
                 "database abstraction",
                 "pdo"
             ],
-            "time": "2020-03-28T00:08:34+00:00"
+            "time": "2020-04-17T04:56:07+00:00"
         },
         {
             "name": "cakephp/datasource",
-            "version": "4.0.5",
+            "version": "4.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/cakephp/datasource.git",
-                "reference": "78f05ea212f9e6014c753601ee2dc8617e9ebe30"
+                "reference": "5d5b1e3cde46fea804d3f4890a02388c4813a982"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cakephp/datasource/zipball/78f05ea212f9e6014c753601ee2dc8617e9ebe30",
-                "reference": "78f05ea212f9e6014c753601ee2dc8617e9ebe30",
+                "url": "https://api.github.com/repos/cakephp/datasource/zipball/5d5b1e3cde46fea804d3f4890a02388c4813a982",
+                "reference": "5d5b1e3cde46fea804d3f4890a02388c4813a982",
                 "shasum": ""
             },
             "require": {
@@ -201,20 +201,20 @@
                 "entity",
                 "query"
             ],
-            "time": "2020-03-13T12:57:56+00:00"
+            "time": "2020-04-16T21:20:43+00:00"
         },
         {
             "name": "cakephp/utility",
-            "version": "4.0.5",
+            "version": "4.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/cakephp/utility.git",
-                "reference": "7e2fb6df26fe8912f364ae4adb58e3707483c598"
+                "reference": "6c6e2a2892d077fa5e6cfdf02e36a821452213af"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cakephp/utility/zipball/7e2fb6df26fe8912f364ae4adb58e3707483c598",
-                "reference": "7e2fb6df26fe8912f364ae4adb58e3707483c598",
+                "url": "https://api.github.com/repos/cakephp/utility/zipball/6c6e2a2892d077fa5e6cfdf02e36a821452213af",
+                "reference": "6c6e2a2892d077fa5e6cfdf02e36a821452213af",
                 "shasum": ""
             },
             "require": {
@@ -254,7 +254,7 @@
                 "string",
                 "utility"
             ],
-            "time": "2020-02-07T20:50:22+00:00"
+            "time": "2020-04-17T04:56:07+00:00"
         },
         {
             "name": "psr/container",

--- a/php/www/html/show_member.php
+++ b/php/www/html/show_member.php
@@ -9,6 +9,11 @@
 <?php
 require("common.php");
 $id = $_POST['id'];
+$sql = 'SELECT * FROM members WHERE id=?';
+$stmt = $dbh -> prepare($sql);
+$data[] = $id;
+$stmt -> execute($data);
+
 $rec = $stmt->fetch(PDO::FETCH_ASSOC);
 $name = $rec['name'];
 $email = $rec['email'];

--- a/php/www/html/show_member.php
+++ b/php/www/html/show_member.php
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Document</title>
+</head>
+<body>
+<?php
+require("common.php");
+$id = $_POST['id'];
+$rec = $stmt->fetch(PDO::FETCH_ASSOC);
+$name = $rec['name'];
+$email = $rec['email'];
+?>
+  <div class="container">
+      <h2>メンバー情報</h2>
+      <p>id:<?php echo $id; ?></p>
+      <p>名前:<?php echo $name; ?></p>
+      <p>id:<?php echo $email; ?></p>
+      <input type="button" onclick="history.back()" value="back">
+  </div>
+</body>
+</html>

--- a/php/www/html/show_member.php
+++ b/php/www/html/show_member.php
@@ -17,7 +17,7 @@ $email = $rec['email'];
       <h2>メンバー情報</h2>
       <p>id:<?php echo $id; ?></p>
       <p>名前:<?php echo $name; ?></p>
-      <p>id:<?php echo $email; ?></p>
+      <p>メール:<?php echo $email; ?></p>
       <input type="button" onclick="history.back()" value="back">
   </div>
 </body>


### PR DESCRIPTION
## 概要
- メンバー一覧の「詳細ページ」をクリックした後に遷移するページの作成

## 想定動作
- メンバー一覧ページで選択したメンバーの下記情報の詳細が表示される
  - id
  - 名前
  - email

## 注意点
- 現状では正しく動作しません

## ToDo
- メンバー一覧ページから選択したメンバーのidを送る(list.phpでの処理)
- sqlの処理でidを元にname/emailを取得する
